### PR TITLE
Feature: Implement Eureka Server for Service Discovery

### DIFF
--- a/eureka-server/src/main/java/com/todoapp/eureka/EurekaServerApplication.java
+++ b/eureka-server/src/main/java/com/todoapp/eureka/EurekaServerApplication.java
@@ -1,0 +1,13 @@
+package com.todoapp.eureka;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@SpringBootApplication
+@EnableEurekaServer
+public class EurekaServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(EurekaServerApplication.class, args);
+    }
+}

--- a/eureka-server/src/main/resources/application.yml
+++ b/eureka-server/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+server:
+  port: 8761
+
+spring:
+  application:
+    name: eureka-server
+
+eureka:
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+  server:
+    enableSelfPreservation: false
+    evictionIntervalTimerInMs: 5000


### PR DESCRIPTION
## Summary
- Implemented Eureka Server as the service discovery component
- Configured server to run on port 8761
- Added necessary Spring Cloud dependencies

## Changes
- Created `EurekaServerApplication.java` with `@EnableEurekaServer` annotation
- Added `application.yml` with Eureka configuration
- Disabled self-registration since this is the Eureka server itself

## Testing
- Run `mvn spring-boot:run` in the eureka-server directory
- Access Eureka dashboard at http://localhost:8761

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)